### PR TITLE
uncomment deleteCanvasObject on Keydown

### DIFF
--- a/src/components/CanvasEventListeners.ts
+++ b/src/components/CanvasEventListeners.ts
@@ -62,7 +62,7 @@ export default function CanvasEventListeners() {
     const onKeyDown = (event: KeyboardEvent) => {
       if (isModalActive) return;
       if (['Backspace', 'Delete'].includes(event.key) && activeObjectId) {
-        //deleteCanvasObject(activeObjectId);
+        deleteCanvasObject(activeObjectId);
       }
     };
     window.addEventListener('keydown', onKeyDown);


### PR DESCRIPTION
I don't know if you forgot to remove the comment or left it like that on purpose, but I need that shortcut.